### PR TITLE
Method parameters can also escape to the heap

### DIFF
--- a/gcassert.go
+++ b/gcassert.go
@@ -260,6 +260,9 @@ func GCAssertCwd(w io.Writer, cwd string, paths ...string) error {
 						if strings.HasSuffix(message, "escapes to heap:") {
 							printAssertionFailure(cwd, fileSet, info.n, w, message)
 						}
+						if strings.Contains(message, "leaking param:") {
+							printAssertionFailure(cwd, fileSet, info.n, w, message)
+						}
 					}
 				}
 				for i := range info.inlinableCallsites {


### PR DESCRIPTION
When this happens the 'go build -gcflags="-m"' output will write something like

offheap/internal/pointerstore/pointer_reference.go:96:7: leaking param: r

This means that the parameter, including the method receiver, escapes to the heap and cannot be stack allocated. Unfortunately it has different text from the usual "escapes to heap:" so it gets missed by gcassert.

Here we include an additional text check for noescape annotations and fail on leaking parameters too.