### PR TITLE
Adding unit tests for 'leaked param'

### DIFF
--- a/gcassert_test.go
+++ b/gcassert_test.go
@@ -82,6 +82,7 @@ func badDirective3() {
 			35: {directives: []assertDirective{noescape}},
 			38: {directives: []assertDirective{noescape}},
 			49: {directives: []assertDirective{noescape}},
+			57: {directives: []assertDirective{noescape}},
 		},
 		"testdata/issue5.go": {
 			4: {inlinableCallsites: []passInfo{{colNo: 14}}},

--- a/gcassert_test.go
+++ b/gcassert_test.go
@@ -76,11 +76,12 @@ func badDirective3() {
 			59: {inlinableCallsites: []passInfo{{colNo: 35}}},
 		},
 		"testdata/noescape.go": {
-			11: {directives: []assertDirective{noescape}},
-			18: {directives: []assertDirective{noescape}},
-			25: {directives: []assertDirective{noescape}},
-			33: {directives: []assertDirective{noescape}},
-			36: {directives: []assertDirective{noescape}},
+			13: {directives: []assertDirective{noescape}},
+			20: {directives: []assertDirective{noescape}},
+			27: {directives: []assertDirective{noescape}},
+			35: {directives: []assertDirective{noescape}},
+			38: {directives: []assertDirective{noescape}},
+			49: {directives: []assertDirective{noescape}},
 		},
 		"testdata/issue5.go": {
 			4: {inlinableCallsites: []passInfo{{colNo: 14}}},
@@ -101,15 +102,23 @@ testdata/bad_directive.go:12:	//gcassert:inline,afterinline
 func badDirective3() {
 	badDirective2()
 }: unknown directive "afterinline"
-testdata/noescape.go:11:	foo := foo{a: 1, b: 2}: foo escapes to heap:
-testdata/noescape.go:25:	// This annotation should fail, because f will escape to the heap.
+testdata/noescape.go:13:	foo := foo{a: 1, b: 2}: foo escapes to heap:
+testdata/noescape.go:27:	// This annotation should fail, because f will escape to the heap.
 //
 //gcassert:noescape
 func (f foo) setA(a int) *foo {
 	f.a = a
 	return &f
 }: f escapes to heap:
-testdata/noescape.go:36:	: a escapes to heap:
+testdata/noescape.go:38:	: a escapes to heap:
+testdata/noescape.go:49:	// This annotation should fail, because the parameter f is leaked.
+// Specifically this means that if you call this method where f was a value
+// (not a pointer) then this will cause a heap allocation.
+//
+//gcassert:noescape
+func (f *foo) printReceiver() {
+	fmt.Printf("#v", f)
+}: leaking param: f
 testdata/bce.go:8:	fmt.Println(ints[5]): Found IsInBounds
 testdata/bce.go:23:	fmt.Println(ints[1:7]): Found IsSliceInBounds
 testdata/bce.go:17:	sum += notInlinable(ints[i]): call was not inlined

--- a/testdata/noescape.go
+++ b/testdata/noescape.go
@@ -49,3 +49,11 @@ func (f foo) returnA(
 func (f *foo) printReceiver() {
 	fmt.Printf("#v", f)
 }
+
+// This annotation should succeed, because the parameter f is not leaked.
+// This is because we don't pass the pointer value f, but its value (*f) instead.
+//
+//gcassert:noescape
+func (f *foo) printValue() {
+	fmt.Printf("#v", *f)
+}

--- a/testdata/noescape.go
+++ b/testdata/noescape.go
@@ -1,5 +1,7 @@
 package gcassert
 
+import "fmt"
+
 type foo struct {
 	a int
 	b int
@@ -37,4 +39,13 @@ func (f foo) returnA(
 	b int,
 ) *int {
 	return &a
+}
+
+// This annotation should fail, because the parameter f is leaked.
+// Specifically this means that if you call this method where f was a value
+// (not a pointer) then this will cause a heap allocation.
+//
+//gcassert:noescape
+func (f *foo) printReceiver() {
+	fmt.Printf("#v", f)
 }


### PR DESCRIPTION
This adds a test for the 'leaked param' case for the noescape annotation.